### PR TITLE
fix none error at metrics

### DIFF
--- a/webapp/prometheus_api/prometheus_handler.py
+++ b/webapp/prometheus_api/prometheus_handler.py
@@ -94,12 +94,13 @@ class PrometheusHandler:
             if source.realtime_status in [SourceStatus.DISABLED, SourceStatus.PROVISIONED]:
                 continue
 
-            last_realtime_update_metrics.metrics.append(
-                SourceMetric(
-                    source=source.uid,
-                    value=int((datetime.now(tz=timezone.utc) - source.realtime_data_updated_at).total_seconds()),
+            if source.realtime_data_updated_at:
+                last_realtime_update_metrics.metrics.append(
+                    SourceMetric(
+                        source=source.uid,
+                        value=int((datetime.now(tz=timezone.utc) - source.realtime_data_updated_at).total_seconds()),
+                    )
                 )
-            )
             source_realtime_parking_site_errors.metrics.append(
                 SourceMetric(
                     source=source.uid,


### PR DESCRIPTION
datetime minus none gives an error, and `realtime_data_updated_at`  can be none if there was never an update ...