### PR TITLE
fix park-api v1 lng field

### DIFF
--- a/webapp/public_rest_api/park_api_v1/park_api_v1_handler.py
+++ b/webapp/public_rest_api/park_api_v1/park_api_v1_handler.py
@@ -57,7 +57,7 @@ class ParkApiV1Handler(GenericParkingSiteHandler):
             lot = {
                 'coords': {
                     'lat': float(parking_site.lat),
-                    'lon': float(parking_site.lon),
+                    'lng': float(parking_site.lon),
                 },
                 'lot_type': self.type_mapping.get(parking_site.type, 'unknown'),
             }

--- a/webapp/public_rest_api/park_api_v1/park_api_v1_schema.py
+++ b/webapp/public_rest_api/park_api_v1/park_api_v1_schema.py
@@ -50,7 +50,7 @@ park_api_v1_parking_site_schema = JsonSchema(
                     'coords': ObjectField(
                         properties={
                             'lat': NumericField(),
-                            'lon': NumericField(),
+                            'lng': NumericField(),
                         },
                     ),
                     'forecast': BooleanField(


### PR DESCRIPTION
Current implementation mixed up lon and lng. This MR uses lng at park-api v1 at every output + docs.