### PR TITLE
delete removed parking sites at updates, several duplicate matching improvements, code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Version 0.5.0
+
+Released 2024-05-30
+
+### Features
+
+* Deletes ParkingSites if they don't exist in the latest pull / push
+* Several Improvements for Duplicate Matching Service:
+  * Don't offer ParkingSites with different purposes as duplicates
+  * Don't offer ParkingSites from the same source as duplicates as this is an data source issue
+  * Add several fields at the duplicate JSON / CSV output
+  * Add header line to duplicate CSVs
+  * Give the ability to set the radius from client side
+
+
+### Fixes
+
+* Add missing fields to OpenAPI documentation
+
+
 ## Version 0.4.3
 
 Released 2024-05-29

--- a/scripts/_helper.py
+++ b/scripts/_helper.py
@@ -9,9 +9,14 @@ from pathlib import Path
 
 def load_duplicates(duplicates_file_path: Path, ignore: bool = False) -> list[tuple[int, int]]:
     old_duplicates: list[tuple[int, int]] = []
+    first = True
     with open(duplicates_file_path) as duplicates_file:
         rows = csv.reader(duplicates_file)
         for row in rows:
+            if first:
+                # We ignore the first line as this is our header
+                first = False
+                continue
             # For applying, we just want to get ignored datasets
             if ignore and row[2] != 'IGNORE':
                 continue
@@ -20,11 +25,38 @@ def load_duplicates(duplicates_file_path: Path, ignore: bool = False) -> list[tu
 
 
 def save_duplicates(duplicates_file_path: Path, items: list[dict], append: bool = False):
-    mapping = ['id', 'duplicate_id', 'status', 'source_id', 'source_uid', 'lat', 'lon', 'address', 'capacity']
+    mapping = [
+        'id',
+        'duplicate_id',
+        'status',
+        'source_id',
+        'source_uid',
+        'lat',
+        'lon',
+        'name',
+        'address',
+        'capacity',
+        'api_url',
+        'type',
+        'park_and_ride_type',
+        'description',
+        'photo_url',
+        'public_url',
+        'opening_hours',
+    ]
     with open(duplicates_file_path, 'a' if append else 'w') as duplicates_file:
         duplicate_csv = csv.writer(duplicates_file)
+        # Write header if not appending
+        if append is False:
+            duplicate_csv.writerow(mapping)
         for item in items:
             row = []
             for field in mapping:
-                row.append(item.get(field) or '')
+                if item.get(field) is None:
+                    value = ''
+                elif isinstance(item[field], list):
+                    value = ','.join(item[field])
+                else:
+                    value = str(item[field])
+                row.append(value)
             duplicate_csv.writerow(row)

--- a/scripts/apply-duplicates.py
+++ b/scripts/apply-duplicates.py
@@ -3,15 +3,14 @@ Copyright 2024 binary butterfly GmbH
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE.txt.
 """
 
+import argparse
 import sys
 from getpass import getpass
+from pathlib import Path
 from typing import Optional
 
 import requests
-import argparse
-from pathlib import Path
-
-from _constants import DUPLICATES_BASE_PATH, USER_AGENT, DEFAULT_BASE_URL
+from _constants import DEFAULT_BASE_URL, DUPLICATES_BASE_PATH, USER_AGENT
 from _helper import load_duplicates, save_duplicates
 
 
@@ -50,10 +49,11 @@ def main():
             'Content-Type': 'application/json',
             'User-Agent': USER_AGENT,
         },
+        timeout=300,
     )
     if requests_response.status_code != 204:
         sys.exit(f'Invalid http response code: {requests_response.status_code}')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/scripts/push-client.py
+++ b/scripts/push-client.py
@@ -9,8 +9,7 @@ from getpass import getpass
 from pathlib import Path
 
 import requests
-
-from _constants import DEFAULT_BASE_URL, DATA_TYPES, PUSH_BASE_PATH, USER_AGENT
+from _constants import DATA_TYPES, DEFAULT_BASE_URL, PUSH_BASE_PATH, USER_AGENT
 
 
 def main():
@@ -51,10 +50,11 @@ def main():
             'Content-Type': DATA_TYPES[file_ending],
             'User-Agent': USER_AGENT,
         },
+        timeout=300,
     )
 
     if requests_response.status_code == 200:
-        print(f'Upload successful. Result: {requests_response.json()}')
+        print(f'Upload successful. Result: {requests_response.json()}')  # noqa: T201
         return
 
     if requests_response.status_code == 400:
@@ -66,5 +66,5 @@ def main():
     sys.exit(f'Unknown error with HTTP status code {requests_response.status_code}.')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/webapp/admin_rest_api/parking_sites/parking_site_handler.py
+++ b/webapp/admin_rest_api/parking_sites/parking_site_handler.py
@@ -3,6 +3,8 @@ Copyright 2024 binary butterfly GmbH
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE.txt.
 """
 
+from typing import Optional
+
 from validataclass_search_queries.pagination import PaginatedResult
 
 from webapp.admin_rest_api import AdminApiBaseHandler
@@ -27,10 +29,10 @@ class ParkingSiteHandler(AdminApiBaseHandler):
     def get_parking_site(self, parking_site_id: int) -> ParkingSite:
         return self.parking_site_repository.fetch_parking_site_by_id(parking_site_id)
 
-    def generate_duplicates(self, duplicate_ids: list[list[int]]) -> list[DuplicatedParkingSite]:
+    def generate_duplicates(self, duplicate_ids: list[list[int]], radius: Optional[int] = None) -> list[DuplicatedParkingSite]:
         duplicate_ids: list[tuple[int, int]] = [(duplicate[0], duplicate[1]) for duplicate in duplicate_ids]
 
-        return self.matching_service.generate_duplicates(duplicate_ids)
+        return self.matching_service.generate_duplicates(duplicate_ids, match_radius=radius)
 
     def apply_duplicates(self, duplicate_ids: list[list[int]]) -> list[DuplicatedParkingSite]:
         duplicate_ids: list[tuple[int, int]] = [(duplicate[0], duplicate[1]) for duplicate in duplicate_ids]

--- a/webapp/admin_rest_api/parking_sites/parking_site_rest_api.py
+++ b/webapp/admin_rest_api/parking_sites/parking_site_rest_api.py
@@ -3,15 +3,15 @@ Copyright 2024 binary butterfly GmbH
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE.txt.
 """
 
-from flask_openapi.decorator import document
 from validataclass.validators import DataclassValidator, IntegerValidator, ListValidator
 
 from webapp.admin_rest_api import AdminApiBaseBlueprint, AdminApiBaseMethodView
+from webapp.common.json import empty_json_response
 from webapp.dependencies import dependencies
+from webapp.shared.parking_site.parking_site_search_query import ParkingSiteSearchInput
 
-from ...common.json import empty_json_response
-from ...shared.parking_site.parking_site_search_query import ParkingSiteSearchInput
 from .parking_site_handler import ParkingSiteHandler
+from .parking_site_validators import GetDuplicatesInput
 
 
 class ParkingSitesBlueprint(AdminApiBaseBlueprint):
@@ -84,12 +84,12 @@ class ParkingSiteMethodView(ParkingSiteBaseMethodView):
 
 
 class ParkingSiteDuplicatesGenerateMethodView(ParkingSiteBaseMethodView):
-    duplicate_ids_validator = ListValidator(ListValidator(IntegerValidator(), min_length=2, max_length=2))
+    duplicate_validator = DataclassValidator(GetDuplicatesInput)
 
     def post(self):
-        duplicate_ids: list[list[int]] = self.duplicate_ids_validator.validate(self.request_helper.get_parsed_json())
+        duplicate_input: GetDuplicatesInput = self.duplicate_validator.validate(self.request_helper.get_parsed_json())
 
-        return self.parking_site_handler.generate_duplicates(duplicate_ids)
+        return self.parking_site_handler.generate_duplicates(duplicate_input.old_duplicates, duplicate_input.radius)
 
 
 class ParkingSiteDuplicatesApplyMethodView(ParkingSiteBaseMethodView):

--- a/webapp/admin_rest_api/parking_sites/parking_site_validators.py
+++ b/webapp/admin_rest_api/parking_sites/parking_site_validators.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2024 binary butterfly GmbH
+Use of this source code is governed by an MIT-style license that can be found in the LICENSE.txt.
+"""
+
+from typing import Optional
+
+from validataclass.dataclasses import Default, validataclass
+from validataclass.validators import IntegerValidator, ListValidator, Noneable
+
+
+@validataclass
+class GetDuplicatesInput:
+    old_duplicates: list[list[int]] = ListValidator(ListValidator(IntegerValidator(min_value=1), min_length=2, max_length=2))
+    radius: Optional[int] = Noneable(IntegerValidator(min_value=1)), Default(None)

--- a/webapp/common/events/event_helper.py
+++ b/webapp/common/events/event_helper.py
@@ -8,8 +8,8 @@ from typing import Dict, List, Optional, Sequence
 from webapp.common.celery import CeleryHelper
 from webapp.common.contexts import ContextHelper
 from webapp.common.logging import Logger
+from webapp.common.logging.models import LogMessageType
 
-from ..logging.models import LogMessageType
 from .delayed_events import trigger_delayed_event
 from .enum import EventSource, EventType
 from .event import Event

--- a/webapp/common/logging/loki_handler.py
+++ b/webapp/common/logging/loki_handler.py
@@ -9,9 +9,8 @@ from logging.handlers import QueueHandler, QueueListener
 from queue import Queue
 from typing import Optional
 
-from flask import Flask
+from webapp.common.config import ConfigHelper
 
-from ..config import ConfigHelper
 from .loki_emitter import BasicAuth, LokiEmitter
 
 

--- a/webapp/public_rest_api/parking_sites/parking_sites_rest_api.py
+++ b/webapp/public_rest_api/parking_sites/parking_sites_rest_api.py
@@ -15,7 +15,8 @@ from flask_openapi.decorator import (
     SchemaReference,
     document,
 )
-from flask_openapi.schema import ArrayField, IntegerField, NumericField, StringField
+from flask_openapi.schema import ArrayField, BooleanField, EnumField, IntegerField, NumericField, StringField
+from parkapi_sources.models.enums import PurposeType
 from validataclass.validators import DataclassValidator
 
 from webapp.dependencies import dependencies
@@ -86,6 +87,12 @@ class ParkingSiteListMethodView(ParkingSiteBaseMethodView):
             Parameter('radius', schema=NumericField(), description='Radius, in m', example='3500'),
             Parameter('limit', schema=IntegerField(), description='Limit results'),
             Parameter('start', schema=IntegerField(), description='Start of search query.'),
+            Parameter('purpose', schema=EnumField(enum=PurposeType)),
+            Parameter(
+                'ignore_duplicates',
+                schema=BooleanField(),
+                description='Defaults to true. If set to false, you will get ParkingSites flagged as duplicates, too.',
+            ),
         ],
         response=[
             Response(


### PR DESCRIPTION
* Deletes ParkingSites if they don't exist in the latest pull / push
* Several Improvements for Duplicate Matching Service:
  * Don't offer ParkingSites with different purposes as duplicates
  * Don't offer ParkingSites from the same source as duplicates as this is an data source issue
  * Add several fields at the duplicate JSON / CSV output
  * Add header line to duplicate CSVs
  * Give the ability to set the radius from client side
* Add missing fields to OpenAPI documentation