### PR TITLE
ParkAPI 0.7.1 with ParkAPI Sources 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.7.1
+
+Released 2024-07-13
+
+### Fixes
+
+* [ParkAPI Sources: Fix Herrenberg base class to fix realtime updates](https://github.com/ParkenDD/parkapi-sources-v3/pull/73)
+
+
 ## Version 0.7.0
 
 Released 2024-07-13

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ openpyxl~=3.1.5
 opening-hours-py~=0.6.18
 kombu~=5.3.7
 lxml~=5.2.2
-parkapi-sources~=0.6.0
+parkapi-sources~=0.6.1
 
 # required for converters
 beautifulsoup4~=4.12.3


### PR DESCRIPTION
... because of wrong BaseClass at Herrenberg