### PR TITLE
Hotfix ParkAPI OpeningTime output for ParkAPI v1

### DIFF
--- a/webapp/public_rest_api/park_api_v1/park_api_v1_handler.py
+++ b/webapp/public_rest_api/park_api_v1/park_api_v1_handler.py
@@ -72,7 +72,7 @@ class ParkApiV1Handler(GenericParkingSiteHandler):
                 lot['state'] = parking_site.realtime_opening_status.name.lower()
             elif parking_site.opening_hours:
                 oh = OpeningHours(parking_site.opening_hours)
-                lot['state'] = oh.state()
+                lot['state'] = str(oh.state())
             else:
                 lot['state'] = 'unknown'
 


### PR DESCRIPTION
Fixes an issue with OpeningHours update which changed the output to a non-`jsonify`able dict, leading to HTTP 500 at ParkAPI v1 output