### PR TITLE
clearify duplicate filter approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ using following optional options:
 - `-si` to limit sources to a list of source ids. Has to be used like `-si 1 2 3`
 - `-su` to limit sources to a list of source uids. Has to be used like `-su source1 source2 source3`
 
+The source filter parameters `-si` and `-su` trigger a filter in which one of the parking sites has to be in this
+source list. For example, with `-si 1` you will get any duplicate between source 1 and some other source without a
+filter.
+
 `-si` and `-su` are mutually exclusive and need to be set as the last parameter.
 `get-new-duplicates.py username -su source1 source2` works, `get-new-duplicates.py -su source1 source2 username` does
 not.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ parkapi-sources~=0.16.1
 beautifulsoup4~=4.12.3
 pyproj~=3.7.0
 
-# binary butterfly shared libraries (https://git.sectio-aurea.org/public_libraries)
---extra-index-url https://git.sectio-aurea.org/api/v4/groups/262/-/packages/pypi/simple
+# binary butterfly shared libraries (https://git.binary-butterfly.de/public_libraries)
+--extra-index-url https://git.binary-butterfly.de/api/v4/groups/262/-/packages/pypi/simple
 validataclass-search-queries~=0.5.1
 flask-openapi~=2.0.3

--- a/tests/integration/admin_rest_api/parking_sites_test.py
+++ b/tests/integration/admin_rest_api/parking_sites_test.py
@@ -21,7 +21,7 @@ def test_generate_duplicates_simple(
     assert result.status_code == 200
     duplicates = result.json
 
-    # As we just output duplicates where each site is at another source. and we have three sources, we expect
+    # As we just output duplicates where each site is at another source, and we have three sources, we expect
     # two duplicates pairs, therefor four datasets
     assert len(duplicates) == 4
 
@@ -35,13 +35,13 @@ def test_generate_duplicates_source_uids(
         auth=('dev', 'test'),
         json={
             'radius': 25000,
-            'source_uids': ['source-1', 'source-2'],
+            'source_uids': ['source-1'],
         },
     )
 
     assert result.status_code == 200
     duplicates = result.json
 
-    # As we just output duplicates where each site is at another source. and we have three sources, filtered to two,
-    # we expect one duplicates pairs
+    # As we just output duplicates where each site is at another source, and we have three sources, filtered to one,
+    # we expect two duplicates pairs, because the other pair is between source-2 and source-3
     assert len(duplicates) == 2

--- a/tests/integration/services/matching_service/matching_service_test.py
+++ b/tests/integration/services/matching_service/matching_service_test.py
@@ -45,7 +45,7 @@ class MatchingServiceTest:
         multi_source_parking_site_test_data: None,
         matching_service: MatchingService,
     ) -> None:
-        duplicates = matching_service.generate_duplicates(existing_matches=[], match_radius=25000, source_ids=[1, 2])
+        duplicates = matching_service.generate_duplicates(existing_matches=[], match_radius=25000, source_ids=[1])
         # As we just output duplicates where each site is at another source. and we have two selected sources, we
-        # expect two duplicates pairs, therefor four datasets
+        # expect one duplicates pair, because the other one is between source 2 and 3.
         assert len(duplicates) == 2

--- a/webapp/repositories/parking_site_repository.py
+++ b/webapp/repositories/parking_site_repository.py
@@ -156,7 +156,7 @@ class ParkingSiteRepository(BaseRepository):
             return query.filter(ParkingSite.duplicate_of_parking_site_id.is_(None))
         return super()._apply_bound_search_filter(query, bound_filter)
 
-    def fetch_parking_site_locations(self, source_ids: list[int] | None = None) -> list[ParkingSiteLocation]:
+    def fetch_parking_site_locations(self) -> list[ParkingSiteLocation]:
         query = self.session.query(
             ParkingSite.id,
             ParkingSite.lat,
@@ -164,8 +164,6 @@ class ParkingSiteRepository(BaseRepository):
             ParkingSite.source_id,
             ParkingSite.purpose,
         )
-        if source_ids is not None:
-            query = query.filter(ParkingSite.source_id.in_(source_ids))
 
         result: list[ParkingSiteLocation] = []
         for item in query.all():

--- a/webapp/services/matching_service/matching_service.py
+++ b/webapp/services/matching_service/matching_service.py
@@ -60,9 +60,17 @@ class MatchingService(BaseService):
         if match_radius is None:
             match_radius: int = self.config_helper.get('MATCH_RADIUS', 100)
 
-        parking_site_locations = self.parking_site_repository.fetch_parking_site_locations(source_ids=source_ids)
+        parking_site_locations = self.parking_site_repository.fetch_parking_site_locations()
         for i in range(len(parking_site_locations)):
             for j in range(i + 1, len(parking_site_locations)):
+                # If source_ids is set, we just want matches for these, so we continue for any other source id
+                if (
+                    source_ids is not None
+                    and parking_site_locations[i].source_id not in source_ids
+                    and parking_site_locations[j].source_id not in source_ids
+                ):
+                    continue
+
                 # If both datasets are from the same source: ignore possible match
                 if parking_site_locations[i].source_id == parking_site_locations[j].source_id:
                     continue


### PR DESCRIPTION
After a clearification round, the mechanism changed a bit to match common needs for duplicate filtering (per-source view). Also added to documentation.