### PR TITLE
fix parkapi v1 docs

### DIFF
--- a/webapp/public_rest_api/park_api_v1/park_api_v1_schema.py
+++ b/webapp/public_rest_api/park_api_v1/park_api_v1_schema.py
@@ -70,7 +70,7 @@ park_api_v1_parking_site_schema = JsonSchema(
                     'capacity': IntegerField(
                         description='Capacity including all used sparking spots and without longterm parking spots.',
                     ),
-                    'public_url': UriField(required=False),
+                    'url': UriField(required=False),
                     'opening_hours': StringField(required=False, description='In OSM opening_hours format'),
                     'fee_hours': StringField(
                         required=False,


### PR DESCRIPTION
... it's `url`, not `public_url`, as it's already implemented, but documented wrong.