### PR TITLE
Fixed bug in setting realtime_free_capacity greater than capacity

### DIFF
--- a/webapp/services/import_service/generic/generic_import_service.py
+++ b/webapp/services/import_service/generic/generic_import_service.py
@@ -320,7 +320,7 @@ class ParkingSiteGenericImportService(BaseService):
 
             if realtime_capacity is UnsetValue or realtime_capacity is None:
                 if realtime_free_capacity > parking_site_capacity:
-                    setattr(realtime_parking_site_input, realtime_free_capacity, parking_site_capacity)
+                    setattr(realtime_parking_site_input, f'realtime_free_{capacity_field}', parking_site_capacity)
                     self.logger.warning(
                         LogMessageType.FAILED_PARKING_SITE_HANDLING,
                         f'At {parking_site.original_uid} from {source.id}, '
@@ -330,7 +330,7 @@ class ParkingSiteGenericImportService(BaseService):
 
             if realtime_capacity is not UnsetValue and realtime_capacity is not None:
                 if realtime_free_capacity > realtime_capacity:
-                    setattr(realtime_parking_site_input, realtime_free_capacity, realtime_capacity)
+                    setattr(realtime_parking_site_input, f'realtime_free_{capacity_field}', realtime_capacity)
                     self.logger.warning(
                         LogMessageType.FAILED_PARKING_SITE_HANDLING,
                         f'At {parking_site.original_uid} from {source.id}, '


### PR DESCRIPTION
This PR fixes the bug in setting ```realtime_free_capacity``` values to ```capacity``` or ```realtime_capacity``` values, whenever the ```realtime_free_capacity``` values are greater than the values of any of the capacity types. The bug originates from setting capacity values in place of the capacity fields.