### PR TITLE
legacy api fields support

### DIFF
--- a/tests/request_input/admin_rest_api/parking-site-item-with-legacy-fields.json
+++ b/tests/request_input/admin_rest_api/parking-site-item-with-legacy-fields.json
@@ -1,0 +1,20 @@
+{
+  "uid": "12717250",
+  "lat": "54.03005",
+  "lon": "5.12696",
+  "name": "Parkhaus Hofdiener",
+  "operator_name": "PBW Parkraumgesellschaft Baden-Württenberg mbH",
+  "address": "Schellingstraße",
+  "opening_hours": "24/7",
+  "capacity": 158,
+  "has_realtime_data": true,
+  "type": "ON_STREET",
+  "realtime_opening_status": "OPEN",
+  "realtime_capacity": 158,
+  "realtime_free_capacity": 15,
+  "capacity_disabled": 11,
+  "realtime_capacity_disabled": 10,
+  "realtime_free_capacity_disabled": 2,
+  "static_data_updated_at": "2023-12-12T13:27:54+01:00",
+  "realtime_data_updated_at": "2025-06-24T13:54:45+02:00"
+}

--- a/tests/request_input/admin_rest_api/parking-site-item-with-relations.json
+++ b/tests/request_input/admin_rest_api/parking-site-item-with-relations.json
@@ -1,0 +1,35 @@
+{
+  "uid": "12717250",
+  "lat": "54.03005",
+  "lon": "5.12696",
+  "name": "Parkhaus Hofdiener",
+  "operator_name": "PBW Parkraumgesellschaft Baden-Württenberg mbH",
+  "address": "Schellingstraße",
+  "opening_hours": "24/7",
+  "capacity": 158,
+  "has_realtime_data": true,
+  "type": "ON_STREET",
+  "realtime_opening_status": "OPEN",
+  "realtime_capacity": 158,
+  "realtime_free_capacity": 15,
+  "static_data_updated_at": "2023-12-12T13:27:54+01:00",
+  "realtime_data_updated_at": "2025-06-24T13:54:45+02:00",
+  "restrictions": [
+    {
+      "max_stay": "PT2H"
+    },
+    {
+      "type": "DISABLED",
+      "max_stay": "PT12H",
+      "capacity": 11,
+      "realtime_capacity": 10,
+      "realtime_free_capacity": 2
+    }
+  ],
+  "external_identifiers": [
+    {
+      "type": "OSM",
+      "value": "123456789"
+    }
+  ]
+}

--- a/tests/request_input/admin_rest_api/parking-site-list-with-legacy-fields.json
+++ b/tests/request_input/admin_rest_api/parking-site-list-with-legacy-fields.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "uid": "12717250",
+      "lat": "54.03005",
+      "lon": "5.12696",
+      "name": "Parkhaus Hofdiener",
+      "operator_name": "PBW Parkraumgesellschaft Baden-Württenberg mbH",
+      "address": "Schellingstraße",
+      "opening_hours": "24/7",
+      "capacity": 158,
+      "has_realtime_data": true,
+      "type": "ON_STREET",
+      "realtime_opening_status": "OPEN",
+      "realtime_capacity": 158,
+      "realtime_free_capacity": 15,
+      "capacity_disabled": 11,
+      "realtime_capacity_disabled": 10,
+      "realtime_free_capacity_disabled": 2,
+      "static_data_updated_at": "2023-12-12T13:27:54+01:00",
+      "realtime_data_updated_at": "2025-06-24T13:54:45+02:00"
+    },
+    {
+      "uidx": 79151538,
+      "lat": 54.03151,
+      "lon": 5.1314,
+      "name": "Bülow Carre",
+      "operator_name": "Stuttgarter Heimschutz",
+      "address": "",
+      "opening_hours": "24/7",
+      "capacity": 108,
+      "has_realtime_data": true,
+      "realtime_opening_status": "OPEN",
+      "realtime_capacity": 108,
+      "realtime_free_capacity": 90,
+      "capacity_disabled": 21,
+      "realtime_capacity_disabled": 20,
+      "realtime_free_capacity_disabled": 4,
+      "static_data_updated_at": "2025-06-18T13:43:51+02:00",
+      "realtime_data_updated_at": "2025-06-10T10:51:09+02:00"
+    }
+  ]
+}

--- a/webapp/admin_rest_api/parking_sites/parking_site_validators.py
+++ b/webapp/admin_rest_api/parking_sites/parking_site_validators.py
@@ -3,8 +3,107 @@ Copyright 2024 binary butterfly GmbH
 Use of this source code is governed by an MIT-style license that can be found in the LICENSE.txt.
 """
 
+from dataclasses import fields
+from typing import Any
+
+from parkapi_sources.models import CombinedParkingSiteInput, ParkingAudience, ParkingSiteRestrictionInput
 from validataclass.dataclasses import Default, validataclass
 from validataclass.validators import AnythingValidator, IntegerValidator, ListValidator, Noneable, StringValidator
+
+CAPACITY_TYPES: dict[str, ParkingAudience] = {
+    'disabled': ParkingAudience.DISABLED,
+    'woman': ParkingAudience.WOMEN,
+    'family': ParkingAudience.FAMILY,
+    'charging': ParkingAudience.CHARGING,
+    'carsharing': ParkingAudience.CARSHARING,
+    'truck': ParkingAudience.TRUCK,
+    'bus': ParkingAudience.BUS,
+}
+
+
+@validataclass
+class LegacyCombinedParkingSiteInput(CombinedParkingSiteInput):
+    capacity_disabled: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    capacity_woman: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    capacity_family: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    capacity_charging: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    capacity_carsharing: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    capacity_truck: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    capacity_bus: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+
+    realtime_capacity_disabled: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    realtime_capacity_woman: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    realtime_capacity_family: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    realtime_capacity_charging: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    realtime_capacity_carsharing: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_capacity_truck: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+    realtime_capacity_bus: int | None = Noneable(IntegerValidator(min_value=0, allow_strings=True)), Default(None)
+
+    realtime_free_capacity_disabled: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_free_capacity_woman: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_free_capacity_family: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_free_capacity_charging: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_free_capacity_carsharing: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_free_capacity_truck: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+    realtime_free_capacity_bus: int | None = (
+        Noneable(IntegerValidator(min_value=0, allow_strings=True)),
+        Default(None),
+    )
+
+    def to_combined_parking_site_input(self) -> CombinedParkingSiteInput:
+        combined_parking_site_dict: dict[str, Any] = {}
+        # prevent recursive dataclass to dict by using fields
+        for field in fields(self):
+            key = field.name
+            if key.endswith(tuple(CAPACITY_TYPES.keys())):
+                continue
+
+            combined_parking_site_dict[key] = getattr(self, key)
+
+        combined_parking_site_input = CombinedParkingSiteInput(**combined_parking_site_dict)
+
+        for key, audience in CAPACITY_TYPES.items():
+            if getattr(self, f'capacity_{key}') is not None:
+                combined_parking_site_input.restrictions.append(
+                    ParkingSiteRestrictionInput(
+                        type=audience,
+                        capacity=getattr(self, f'capacity_{key}'),
+                        realtime_capacity=getattr(self, f'realtime_capacity_{key}'),
+                        realtime_free_capacity=getattr(self, f'realtime_free_capacity_{key}'),
+                    ),
+                )
+
+        return combined_parking_site_input
 
 
 @validataclass

--- a/webapp/models/parking_site.py
+++ b/webapp/models/parking_site.py
@@ -214,6 +214,9 @@ class ParkingSite(BaseModel):
             # Legacy output
             result['restricted_to'] = []
             for restrictions in self.restrictions:
+                # It would be misleading to output a restriction without capacity at the legacy field
+                if restrictions.capacity is not None:
+                    continue
                 result['restricted_to'].append(restrictions.to_dict(fields=['type', 'hours', 'max_stay']))
 
         if include_external_identifiers and len(self.external_identifiers):

--- a/webapp/services/import_service/generic/generic_parking_site_import_service.py
+++ b/webapp/services/import_service/generic/generic_parking_site_import_service.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 
 from parkapi_sources.exceptions import ImportParkingSiteException
 from parkapi_sources.models import (
+    CombinedParkingSiteInput,
     ParkingAudience,
     ParkingSiteRestrictionInput,
     RealtimeParkingSiteInput,
@@ -127,6 +128,19 @@ class GenericParkingSiteImportService(GenericBaseImportService):
             if restriction_input.type not in RESTRICTION_MAPPING:
                 continue
             setattr(parking_site, RESTRICTION_MAPPING[restriction_input.type], restriction_input.capacity)
+
+            # Don't overwrite realtime data in case of static data
+            if isinstance(parking_site_input, CombinedParkingSiteInput):
+                setattr(
+                    parking_site,
+                    f'realtime_{RESTRICTION_MAPPING[restriction_input.type]}',
+                    restriction_input.realtime_capacity,
+                )
+                setattr(
+                    parking_site,
+                    f'realtime_free_{RESTRICTION_MAPPING[restriction_input.type]}',
+                    restriction_input.realtime_free_capacity,
+                )
 
         if parking_site_input.group_uid:
             try:


### PR DESCRIPTION
Brings back support for the legacy restriction fields like `capacity_disabled` and their realtime equivalents. Also adds more tests to ensure future support.